### PR TITLE
chore: upgrade synthetics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
           node-version: 14.x
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 3.x
+          dotnet-version: 6.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
           node-version: 14.x
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 3.x
+          dotnet-version: 6.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.67.0",
+      "version": "2.68.0",
       "type": "build"
     },
     {
@@ -165,7 +165,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.67.0",
+      "version": "^2.68.0",
       "type": "peer"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.55.1",
+      "version": "2.67.0",
       "type": "build"
     },
     {
@@ -165,7 +165,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.55.1",
+      "version": "^2.67.0",
       "type": "peer"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -2,7 +2,6 @@
   "dependencies": [
     {
       "name": "@aws-cdk/aws-synthetics-alpha",
-      "version": "2.55.1-alpha.0",
       "type": "build"
     },
     {
@@ -162,7 +161,6 @@
     },
     {
       "name": "@aws-cdk/aws-synthetics-alpha",
-      "version": "2.55.1-alpha.0",
       "type": "peer"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -579,19 +579,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='aws-cdk-lib,constructs'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -57,7 +57,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   author: 'Amazon Web Services',
   authorAddress: 'https://aws.amazon.com',
   authorOrganization: true,
-  cdkVersion: '2.67.0',
+  cdkVersion: '2.68.0',
   defaultReleaseBranch: 'main',
   name: '@cdklabs/cdk-ecs-codedeploy',
   description: 'CDK Constructs for performing ECS Deployments with CodeDeploy',

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -31,6 +31,33 @@ export class WorkflowNoDockerPatch {
     );
   }
 }
+export interface WorkflowDotNetVersionPatchOptions {
+  /**
+   * The workflow to patch.
+   */
+  workflow: string;
+  /**
+   * Name of the job.
+   * @default - release_nuget
+   */
+  jobName?: string;
+  /**
+   * dotNet Version
+   */
+  dotNetVersion: string;
+}
+export class WorkflowDotNetVersionPatch {
+  public constructor(project: NodeProject, options: WorkflowDotNetVersionPatchOptions) {
+    const {
+      workflow,
+      jobName = 'release_nuget',
+    } = options;
+
+    project.tryFindObjectFile(`.github/workflows/${workflow}.yml`)?.patch(
+      JsonPatch.replace(`/jobs/${jobName}/steps/1/with/dotnet-version`, options.dotNetVersion),
+    );
+  }
+}
 
 const project = new awscdk.AwsCdkConstructLibrary({
   author: 'Amazon Web Services',
@@ -107,5 +134,7 @@ project.upgradeWorkflow?.postUpgradeTask.spawn(
 
 new WorkflowNoDockerPatch(project, { workflow: 'build' });
 new WorkflowNoDockerPatch(project, { workflow: 'release' });
+
+new WorkflowDotNetVersionPatch(project, { workflow: 'release', dotNetVersion: '6.x'});
 
 project.synth();

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -135,6 +135,6 @@ project.upgradeWorkflow?.postUpgradeTask.spawn(
 new WorkflowNoDockerPatch(project, { workflow: 'build' });
 new WorkflowNoDockerPatch(project, { workflow: 'release' });
 
-new WorkflowDotNetVersionPatch(project, { workflow: 'release', dotNetVersion: '6.x'});
+new WorkflowDotNetVersionPatch(project, { workflow: 'release', dotNetVersion: '6.x' });
 
 project.synth();

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -88,7 +88,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   ],
   deps: [],
   peerDeps: [
-    '@aws-cdk/aws-synthetics-alpha@2.55.1-alpha.0',
+    '@aws-cdk/aws-synthetics-alpha',
   ],
   keywords: [
     'aws',

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -36,7 +36,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   author: 'Amazon Web Services',
   authorAddress: 'https://aws.amazon.com',
   authorOrganization: true,
-  cdkVersion: '2.55.1',
+  cdkVersion: '2.67.0',
   defaultReleaseBranch: 'main',
   name: '@cdklabs/cdk-ecs-codedeploy',
   description: 'CDK Constructs for performing ECS Deployments with CodeDeploy',

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -38,9 +38,8 @@ export interface WorkflowDotNetVersionPatchOptions {
   workflow: string;
   /**
    * Name of the job.
-   * @default - release_nuget
    */
-  jobName?: string;
+  jobName: string;
   /**
    * dotNet Version
    */
@@ -48,13 +47,8 @@ export interface WorkflowDotNetVersionPatchOptions {
 }
 export class WorkflowDotNetVersionPatch {
   public constructor(project: NodeProject, options: WorkflowDotNetVersionPatchOptions) {
-    const {
-      workflow,
-      jobName = 'release_nuget',
-    } = options;
-
-    project.tryFindObjectFile(`.github/workflows/${workflow}.yml`)?.patch(
-      JsonPatch.replace(`/jobs/${jobName}/steps/1/with/dotnet-version`, options.dotNetVersion),
+    project.tryFindObjectFile(`.github/workflows/${options.workflow}.yml`)?.patch(
+      JsonPatch.replace(`/jobs/${options.jobName}/steps/1/with/dotnet-version`, options.dotNetVersion),
     );
   }
 }
@@ -135,6 +129,7 @@ project.upgradeWorkflow?.postUpgradeTask.spawn(
 new WorkflowNoDockerPatch(project, { workflow: 'build' });
 new WorkflowNoDockerPatch(project, { workflow: 'release' });
 
-new WorkflowDotNetVersionPatch(project, { workflow: 'release', dotNetVersion: '6.x' });
+new WorkflowDotNetVersionPatch(project, { workflow: 'build', jobName: 'package-dotnet', dotNetVersion: '6.x' });
+new WorkflowDotNetVersionPatch(project, { workflow: 'release', jobName: 'release_nuget', dotNetVersion: '6.x' });
 
 project.synth();

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "aws-cdk": "^2",
-    "aws-cdk-lib": "2.67.0",
+    "aws-cdk-lib": "2.68.0",
     "aws-sdk-client-mock": "^2.1.0",
     "aws-sdk-client-mock-jest": "^2.1.0",
     "cdk-nag": "^2.22.29",
@@ -96,7 +96,7 @@
   },
   "peerDependencies": {
     "@aws-cdk/aws-synthetics-alpha": "2.68.0-alpha.0",
-    "aws-cdk-lib": "^2.67.0",
+    "aws-cdk-lib": "^2.68.0",
     "constructs": "^10.0.5"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "organization": true
   },
   "devDependencies": {
-    "@aws-cdk/aws-synthetics-alpha": "2.67.0-alpha.0",
-    "@aws-cdk/integ-tests-alpha": "^2.67.0-alpha.0",
+    "@aws-cdk/aws-synthetics-alpha": "2.68.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "^2.68.0-alpha.0",
     "@types/aws-lambda": "^8.10.111",
     "@types/jest": "^27",
     "@types/lambda-tester": "^3.6.2",
@@ -73,7 +73,7 @@
     "aws-cdk-lib": "2.67.0",
     "aws-sdk-client-mock": "^2.1.0",
     "aws-sdk-client-mock-jest": "^2.1.0",
-    "cdk-nag": "^2.22.28",
+    "cdk-nag": "^2.22.29",
     "constructs": "10.0.5",
     "esbuild": "^0.17.11",
     "eslint": "^8",
@@ -84,23 +84,23 @@
     "jest-junit": "^13",
     "jsii": "^1.77.0",
     "jsii-diff": "^1.77.0",
-    "jsii-docgen": "^7.1.18",
+    "jsii-docgen": "^7.1.19",
     "jsii-pacmak": "^1.77.0",
     "lambda-tester": "^4.0.1",
     "npm-check-updates": "^16",
-    "projen": "0.67.75",
+    "projen": "0.67.78",
     "standard-version": "^9",
     "ts-jest": "^27",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-synthetics-alpha": "2.67.0-alpha.0",
+    "@aws-cdk/aws-synthetics-alpha": "2.68.0-alpha.0",
     "aws-cdk-lib": "^2.67.0",
     "constructs": "^10.0.5"
   },
   "dependencies": {
-    "@aws-sdk/client-codedeploy": "^3.282.0",
+    "@aws-sdk/client-codedeploy": "^3.287.0",
     "jmespath": "^0.16.0"
   },
   "bundledDependencies": [

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "organization": true
   },
   "devDependencies": {
-    "@aws-cdk/aws-synthetics-alpha": "2.55.1-alpha.0",
+    "@aws-cdk/aws-synthetics-alpha": "2.67.0-alpha.0",
     "@aws-cdk/integ-tests-alpha": "^2.67.0-alpha.0",
     "@types/aws-lambda": "^8.10.111",
     "@types/jest": "^27",
@@ -95,7 +95,7 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-synthetics-alpha": "2.55.1-alpha.0",
+    "@aws-cdk/aws-synthetics-alpha": "2.67.0-alpha.0",
     "aws-cdk-lib": "^2.55.1",
     "constructs": "^10.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "aws-cdk": "^2",
-    "aws-cdk-lib": "2.55.1",
+    "aws-cdk-lib": "2.67.0",
     "aws-sdk-client-mock": "^2.1.0",
     "aws-sdk-client-mock-jest": "^2.1.0",
     "cdk-nag": "^2.22.28",
@@ -96,7 +96,7 @@
   },
   "peerDependencies": {
     "@aws-cdk/aws-synthetics-alpha": "2.67.0-alpha.0",
-    "aws-cdk-lib": "^2.55.1",
+    "aws-cdk-lib": "^2.67.0",
     "constructs": "^10.0.5"
   },
   "dependencies": {

--- a/src/ecs-patterns/application-load-balanced-codedeployed-fargate-service.ts
+++ b/src/ecs-patterns/application-load-balanced-codedeployed-fargate-service.ts
@@ -173,7 +173,7 @@ export class ApplicationLoadBalancedCodeDeployedFargateService extends Applicati
     const alarms: IAlarm[] = [];
     if (props.responseTimeAlarmThreshold) {
       const responseTimeAlarm = new Alarm(this, 'ResponseTimeAlarm', {
-        metric: this.loadBalancer.metricTargetResponseTime({
+        metric: this.loadBalancer.metrics.targetResponseTime({
           period: Duration.minutes(1),
           statistic: 'p95',
         }),

--- a/test/api-canary.integ.snapshot/TestStack.assets.json
+++ b/test/api-canary.integ.snapshot/TestStack.assets.json
@@ -1,5 +1,5 @@
 {
-  "version": "22.0.0",
+  "version": "30.1.0",
   "files": {
     "93db9dcabf8af9cc80ac1a58b535f16939207937839bf12b4db178e54a4bb659": {
       "source": {

--- a/test/application-load-balanced-codedeployed-fargate-service.integ.snapshot/cdk-ecs-codedeploy-service.assets.json
+++ b/test/application-load-balanced-codedeployed-fargate-service.integ.snapshot/cdk-ecs-codedeploy-service.assets.json
@@ -1,5 +1,5 @@
 {
-  "version": "22.0.0",
+  "version": "30.1.0",
   "files": {
     "93db9dcabf8af9cc80ac1a58b535f16939207937839bf12b4db178e54a4bb659": {
       "source": {
@@ -43,21 +43,21 @@
         }
       }
     },
-    "2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f": {
+    "53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b": {
       "source": {
-        "path": "asset.2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f",
+        "path": "asset.53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-us-west-2": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-us-west-2",
-          "objectKey": "2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f.zip",
+          "objectKey": "53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b.zip",
           "region": "us-west-2",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-us-west-2"
         }
       }
     },
-    "a7b825638766ca70b2f9a486b2a7191c1442c12686b682f139b07752fa7e8ba8": {
+    "325a3ee878e481286e8b7f817e88833a6d3bfe7549bf80398ae099b32dc52f89": {
       "source": {
         "path": "cdk-ecs-codedeploy-service.template.json",
         "packaging": "file"
@@ -65,7 +65,7 @@
       "destinations": {
         "current_account-us-west-2": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-us-west-2",
-          "objectKey": "a7b825638766ca70b2f9a486b2a7191c1442c12686b682f139b07752fa7e8ba8.json",
+          "objectKey": "325a3ee878e481286e8b7f817e88833a6d3bfe7549bf80398ae099b32dc52f89.json",
           "region": "us-west-2",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-us-west-2"
         }

--- a/test/application-load-balanced-codedeployed-fargate-service.integ.snapshot/cdk-ecs-codedeploy-service.template.json
+++ b/test/application-load-balanced-codedeployed-fargate-service.integ.snapshot/cdk-ecs-codedeploy-service.template.json
@@ -1933,11 +1933,7 @@
           {
            "Ref": "AWS::Partition"
           },
-          ":codedeploy:",
-          {
-           "Ref": "AWS::Region"
-          },
-          ":",
+          ":codedeploy:us-west-2:",
           {
            "Ref": "AWS::AccountId"
           },
@@ -1964,11 +1960,7 @@
           {
            "Ref": "AWS::Partition"
           },
-          ":codedeploy:",
-          {
-           "Ref": "AWS::Region"
-          },
-          ":",
+          ":codedeploy:us-west-2:",
           {
            "Ref": "AWS::AccountId"
           },
@@ -1995,11 +1987,7 @@
           {
            "Ref": "AWS::Partition"
           },
-          ":codedeploy:",
-          {
-           "Ref": "AWS::Region"
-          },
-          ":",
+          ":codedeploy:us-west-2:",
           {
            "Ref": "AWS::AccountId"
           },
@@ -2135,11 +2123,7 @@
           {
            "Ref": "AWS::Partition"
           },
-          ":codedeploy:",
-          {
-           "Ref": "AWS::Region"
-          },
-          ":",
+          ":codedeploy:us-west-2:",
           {
            "Ref": "AWS::AccountId"
           },
@@ -2377,7 +2361,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-west-2"
      },
-     "S3Key": "2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f.zip"
+     "S3Key": "53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -2583,7 +2567,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-west-2"
      },
-     "S3Key": "2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f.zip"
+     "S3Key": "53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -2786,7 +2770,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-west-2"
      },
-     "S3Key": "2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f.zip"
+     "S3Key": "53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/ecs-deployment.integ.snapshot/cdk-ecs-codedeploy-ecs-deployment.assets.json
+++ b/test/ecs-deployment.integ.snapshot/cdk-ecs-codedeploy-ecs-deployment.assets.json
@@ -1,5 +1,5 @@
 {
-  "version": "22.0.0",
+  "version": "30.1.0",
   "files": {
     "dd70c9291f90686877dd7eb18ea62ac7d87af05bff8571f92ef962cc9026fa2c": {
       "source": {
@@ -27,20 +27,20 @@
         }
       }
     },
-    "2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f": {
+    "53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b": {
       "source": {
-        "path": "asset.2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f",
+        "path": "asset.53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f.zip",
+          "objectKey": "53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "e5a53d773b55ad6b74584e0b9d19b8f12a3c5a3c32328fba9d8ee6a85109a3fa": {
+    "2f72ba7e89b3c1631bb525404a8db639fb914cbbc079d6cb8c0a39d7a1c7c1ac": {
       "source": {
         "path": "cdk-ecs-codedeploy-ecs-deployment.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e5a53d773b55ad6b74584e0b9d19b8f12a3c5a3c32328fba9d8ee6a85109a3fa.json",
+          "objectKey": "2f72ba7e89b3c1631bb525404a8db639fb914cbbc079d6cb8c0a39d7a1c7c1ac.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/ecs-deployment.integ.snapshot/cdk-ecs-codedeploy-ecs-deployment.template.json
+++ b/test/ecs-deployment.integ.snapshot/cdk-ecs-codedeploy-ecs-deployment.template.json
@@ -1867,7 +1867,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f.zip"
+     "S3Key": "53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -2092,7 +2092,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f.zip"
+     "S3Key": "53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -2314,7 +2314,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "2157f4ab8972014e220d70707296b292b3b7301f163f7cd641ccda0ee663530f.zip"
+     "S3Key": "53c95d71cfd280747d971a38505aea07f812fdba75874a090358a2fc4f58f79b.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -2735,6 +2735,10 @@
    "eu-central-1": {
     "codedeploy": "codedeploy.eu-central-1.amazonaws.com",
     "states": "states.eu-central-1.amazonaws.com"
+   },
+   "eu-central-2": {
+    "codedeploy": "codedeploy.eu-central-2.amazonaws.com",
+    "states": "states.eu-central-2.amazonaws.com"
    },
    "eu-north-1": {
     "codedeploy": "codedeploy.eu-north-1.amazonaws.com",

--- a/test/ecs-deployment.integ.ts
+++ b/test/ecs-deployment.integ.ts
@@ -94,14 +94,14 @@ service.node.addDependency(greenTG);
 // Alarms: monitor 500s and unhealthy hosts on target groups
 const blueUnhealthyHosts = new cloudwatch.Alarm(stack, 'BlueUnhealthyHosts', {
   alarmName: stack.stackName + '-Unhealthy-Hosts-Blue',
-  metric: blueTG.metricUnhealthyHostCount(),
+  metric: blueTG.metrics.unhealthyHostCount(),
   threshold: 1,
   evaluationPeriods: 2,
 });
 
 const blueApiFailure = new cloudwatch.Alarm(stack, 'Blue5xx', {
   alarmName: stack.stackName + '-Http-500-Blue',
-  metric: blueTG.metricHttpCodeTarget(
+  metric: blueTG.metrics.httpCodeTarget(
     elbv2.HttpCodeTarget.TARGET_5XX_COUNT,
     { period: cdk.Duration.minutes(1) },
   ),
@@ -111,14 +111,14 @@ const blueApiFailure = new cloudwatch.Alarm(stack, 'Blue5xx', {
 
 const greenUnhealthyHosts = new cloudwatch.Alarm(stack, 'GreenUnhealthyHosts', {
   alarmName: stack.stackName + '-Unhealthy-Hosts-Green',
-  metric: greenTG.metricUnhealthyHostCount(),
+  metric: greenTG.metrics.unhealthyHostCount(),
   threshold: 1,
   evaluationPeriods: 2,
 });
 
 const greenApiFailure = new cloudwatch.Alarm(stack, 'Green5xx', {
   alarmName: stack.stackName + '-Http-500-Green',
-  metric: greenTG.metricHttpCodeTarget(
+  metric: greenTG.metrics.httpCodeTarget(
     elbv2.HttpCodeTarget.TARGET_5XX_COUNT,
     { period: cdk.Duration.minutes(1) },
   ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,20 +10,20 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/asset-awscli-v1@^2.2.30":
-  version "2.2.97"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.97.tgz#af6fcefe7b9ddecc6656691bd0b4061f5c5eabf2"
-  integrity sha512-bWFkQphw1U7Q8XngShvGy0S1yqDui6q72zjnLciqKQ5ucZq17/TEujLTpSv+v2K5qJU8oa8VaMDiRyYbdPD6MA==
+"@aws-cdk/asset-awscli-v1@^2.2.85":
+  version "2.2.95"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.95.tgz#0bba7976c568c6aefca5032145e0f07f07bcd612"
+  integrity sha512-NehDS2rfGFt9/NCAxX4rIdVb6peFQsME3Ji+i0ENjwiyv52cS2XakW8bJ0IcgNCVQdMm0dnn5r2PQBJ/M62F+Q==
 
 "@aws-cdk/asset-kubectl-v20@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz#d01c1efb867fb7f2cfd8c8b230b8eae16447e156"
   integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
 
-"@aws-cdk/asset-node-proxy-agent-v5@^2.0.38":
-  version "2.0.77"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.77.tgz#25ad8e416945c3a51881eedad3ee84516f23ecee"
-  integrity sha512-KKrnyIujGN38yOb0MIm0EnB3n7z83NRl9VgKvN0flOyB8C+3Ey+XKxLYfjoXJ/BulB0161eBJXXwGdP8xQrQJw==
+"@aws-cdk/asset-node-proxy-agent-v5@^2.0.71":
+  version "2.0.76"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.76.tgz#af9b918de5d3932e4f2c3c66b6b222351e08a68a"
+  integrity sha512-TZx7S0k2O1v+sUJowX8C9/2NJptMNtc/D2bFwEZINaMtlF4njq6Ypr6wOaHNw9TvQIJCfqw4/PgKgROGYJL3DA==
 
 "@aws-cdk/aws-synthetics-alpha@2.67.0-alpha.0":
   version "2.67.0-alpha.0"
@@ -2268,21 +2268,21 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.55.1:
-  version "2.55.1"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.55.1.tgz#4044118ff7a38952abf7f10035bcec5dd1a6f8e9"
-  integrity sha512-v0MhL6RqazQ2HKj9TXJvXKQcQNIDYeRzcOJ2xB2Usz56xodArc2goLu2P51X5J84xOO4w2AgNaWMCBzd7MbyOQ==
+aws-cdk-lib@2.67.0:
+  version "2.67.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.67.0.tgz#ae9d38bba736e4b92feb740d02d1d25dc80644db"
+  integrity sha512-oVD0cZPKTtkGXvFkYLA+vNiq+QzyuQkOe/rDY/BSxi/cEElbu74StKwCFCFGq8ljTAHQjyYeE5dzlB2q8Wq20w==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.30"
+    "@aws-cdk/asset-awscli-v1" "^2.2.85"
     "@aws-cdk/asset-kubectl-v20" "^2.1.1"
-    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.38"
+    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.71"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"
-    ignore "^5.2.1"
+    ignore "^5.2.4"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
-    punycode "^2.1.1"
+    punycode "^2.3.0"
     semver "^7.3.8"
     yaml "1.10.2"
 
@@ -4286,7 +4286,7 @@ ignore-walk@^6.0.0:
   dependencies:
     minimatch "^6.1.6"
 
-ignore@^5.2.0, ignore@^5.2.1:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -6491,7 +6491,7 @@ psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,9 +11,9 @@
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@aws-cdk/asset-awscli-v1@^2.2.85":
-  version "2.2.97"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.97.tgz#af6fcefe7b9ddecc6656691bd0b4061f5c5eabf2"
-  integrity sha512-bWFkQphw1U7Q8XngShvGy0S1yqDui6q72zjnLciqKQ5ucZq17/TEujLTpSv+v2K5qJU8oa8VaMDiRyYbdPD6MA==
+  version "2.2.98"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.98.tgz#74fa0bf8593e9cfbdc68e8eb64977e0adb21cb38"
+  integrity sha512-SRJeHb08wW5FVZN7OrbzHzyxW9HuRek2irRCUc+6YBgIRM1JYlyUSd+vcaPThTllNl7rUf4oNvmyK0/3tWLKDg==
 
 "@aws-cdk/asset-kubectl-v20@^2.1.1":
   version "2.1.1"
@@ -21,19 +21,19 @@
   integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
 
 "@aws-cdk/asset-node-proxy-agent-v5@^2.0.71":
-  version "2.0.77"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.77.tgz#25ad8e416945c3a51881eedad3ee84516f23ecee"
-  integrity sha512-KKrnyIujGN38yOb0MIm0EnB3n7z83NRl9VgKvN0flOyB8C+3Ey+XKxLYfjoXJ/BulB0161eBJXXwGdP8xQrQJw==
+  version "2.0.78"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.78.tgz#dc500bdd5534ca3390d5be7764ca8916c76e6d5d"
+  integrity sha512-NMGFaszbLkLQlxIJ0ydyO+P78cgTEUleGt1nn3CSRyuBHoYkHNGAcY2JUxTFhQc3/AZuq1x4w87zqh7eAOTyTw==
 
-"@aws-cdk/aws-synthetics-alpha@2.67.0-alpha.0":
-  version "2.67.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-synthetics-alpha/-/aws-synthetics-alpha-2.67.0-alpha.0.tgz#5255cc3868d0a0c8dd8ba105d5a1668e2b837536"
-  integrity sha512-snS5Fl/FSlumSGjSZYvQlXqH2tZjoTozo0iXwiQr1MdG0xLJCoiSqa0vBRhVPP5hsNG6qWQ9LIygi5eFmKG4YQ==
+"@aws-cdk/aws-synthetics-alpha@2.68.0-alpha.0":
+  version "2.68.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-synthetics-alpha/-/aws-synthetics-alpha-2.68.0-alpha.0.tgz#1c7b99a10888c22502441694438a314487e232f5"
+  integrity sha512-mrx0ID0vXcrHHBNLeq6E+Bf5eJtyt/xqvMNRIpvyp3k+CKkaa62Rg3kDIjhJdemvSWihzzSu6xNMxvBIqnjK4w==
 
-"@aws-cdk/integ-tests-alpha@^2.67.0-alpha.0":
-  version "2.67.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/integ-tests-alpha/-/integ-tests-alpha-2.67.0-alpha.0.tgz#48464bb7bd203214ffdf3ab4d67e40820151185f"
-  integrity sha512-w4AZByffgzyf6RJHGkkvZF37CwBNSqzNuycpdnwP0/G+2S0tzViwZbGOIY4QcLGwUgEanBEhPr8vPJaXOZ1uzQ==
+"@aws-cdk/integ-tests-alpha@^2.68.0-alpha.0":
+  version "2.68.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/integ-tests-alpha/-/integ-tests-alpha-2.68.0-alpha.0.tgz#a3036ab04fd3c50e6901a2110b03a302bae544d7"
+  integrity sha512-9grtqUJCzlLygT0GbVVAP/MoFkPf05m7wp85830W9YtLKXhYZ77jo8FopNxvuvVDNBLgY6Jz4JCckv7Q9x/0xw==
 
 "@aws-crypto/ie11-detection@^3.0.0":
   version "3.0.0"
@@ -89,30 +89,30 @@
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-codedeploy@^3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-codedeploy/-/client-codedeploy-3.282.0.tgz#eeb86e7ffda33a939193d744dacb14e0229f5fa5"
-  integrity sha512-pJ1A0MARtymB7ncLUqXMNwI48nyPXgFRTepOt8+peCLru8Q5lqVvrnLUc2fpoZOxlR1c6o7nzKyzK1VUR18y2Q==
+"@aws-sdk/client-codedeploy@^3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-codedeploy/-/client-codedeploy-3.287.0.tgz#86c951098a0d9337dd663ca0e4b20990a998b488"
+  integrity sha512-LUmX8BXEqu37N9wKbX6gyUYvvDBB3em/gzmDoR7VQAaEenQZEEo13YPEEkHhN+Csn2ika/+c+ZSObYYrfxK5Yg==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/client-sts" "3.282.0"
-    "@aws-sdk/config-resolver" "3.282.0"
-    "@aws-sdk/credential-provider-node" "3.282.0"
+    "@aws-sdk/client-sts" "3.287.0"
+    "@aws-sdk/config-resolver" "3.287.0"
+    "@aws-sdk/credential-provider-node" "3.287.0"
     "@aws-sdk/fetch-http-handler" "3.282.0"
     "@aws-sdk/hash-node" "3.272.0"
     "@aws-sdk/invalid-dependency" "3.272.0"
     "@aws-sdk/middleware-content-length" "3.282.0"
     "@aws-sdk/middleware-endpoint" "3.282.0"
     "@aws-sdk/middleware-host-header" "3.282.0"
-    "@aws-sdk/middleware-logger" "3.272.0"
+    "@aws-sdk/middleware-logger" "3.287.0"
     "@aws-sdk/middleware-recursion-detection" "3.282.0"
-    "@aws-sdk/middleware-retry" "3.282.0"
+    "@aws-sdk/middleware-retry" "3.287.0"
     "@aws-sdk/middleware-serde" "3.272.0"
     "@aws-sdk/middleware-signing" "3.282.0"
     "@aws-sdk/middleware-stack" "3.272.0"
     "@aws-sdk/middleware-user-agent" "3.282.0"
-    "@aws-sdk/node-config-provider" "3.272.0"
+    "@aws-sdk/node-config-provider" "3.287.0"
     "@aws-sdk/node-http-handler" "3.282.0"
     "@aws-sdk/protocol-http" "3.282.0"
     "@aws-sdk/smithy-client" "3.279.0"
@@ -122,36 +122,36 @@
     "@aws-sdk/util-body-length-browser" "3.188.0"
     "@aws-sdk/util-body-length-node" "3.208.0"
     "@aws-sdk/util-defaults-mode-browser" "3.279.0"
-    "@aws-sdk/util-defaults-mode-node" "3.282.0"
+    "@aws-sdk/util-defaults-mode-node" "3.287.0"
     "@aws-sdk/util-endpoints" "3.272.0"
     "@aws-sdk/util-retry" "3.272.0"
     "@aws-sdk/util-user-agent-browser" "3.282.0"
-    "@aws-sdk/util-user-agent-node" "3.282.0"
+    "@aws-sdk/util-user-agent-node" "3.287.0"
     "@aws-sdk/util-utf8" "3.254.0"
     "@aws-sdk/util-waiter" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sso-oidc@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.282.0.tgz#538259969e472e4497f01c8b6fe6fafd59db4147"
-  integrity sha512-upC4yBZllAXg5OVIuS8Lu9MI1aqfAObl2BBixj9fIYbDanQ02s0b1IwfZqlOqNNkGzMko1AWyiOSyOdVgyJ+xg==
+"@aws-sdk/client-sso-oidc@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.287.0.tgz#8e3581ce666f5110bcc2dcfb89066a1e3902850a"
+  integrity sha512-zrUy5jpu32sjmOcSlr8IVNTT/Pfa8ZPj6v0P/sNN3PWIv9fbep/0MJyIwbWJLCfQVLZqRvlMovFzVlnWixjraw==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/config-resolver" "3.282.0"
+    "@aws-sdk/config-resolver" "3.287.0"
     "@aws-sdk/fetch-http-handler" "3.282.0"
     "@aws-sdk/hash-node" "3.272.0"
     "@aws-sdk/invalid-dependency" "3.272.0"
     "@aws-sdk/middleware-content-length" "3.282.0"
     "@aws-sdk/middleware-endpoint" "3.282.0"
     "@aws-sdk/middleware-host-header" "3.282.0"
-    "@aws-sdk/middleware-logger" "3.272.0"
+    "@aws-sdk/middleware-logger" "3.287.0"
     "@aws-sdk/middleware-recursion-detection" "3.282.0"
-    "@aws-sdk/middleware-retry" "3.282.0"
+    "@aws-sdk/middleware-retry" "3.287.0"
     "@aws-sdk/middleware-serde" "3.272.0"
     "@aws-sdk/middleware-stack" "3.272.0"
     "@aws-sdk/middleware-user-agent" "3.282.0"
-    "@aws-sdk/node-config-provider" "3.272.0"
+    "@aws-sdk/node-config-provider" "3.287.0"
     "@aws-sdk/node-http-handler" "3.282.0"
     "@aws-sdk/protocol-http" "3.282.0"
     "@aws-sdk/smithy-client" "3.279.0"
@@ -161,35 +161,35 @@
     "@aws-sdk/util-body-length-browser" "3.188.0"
     "@aws-sdk/util-body-length-node" "3.208.0"
     "@aws-sdk/util-defaults-mode-browser" "3.279.0"
-    "@aws-sdk/util-defaults-mode-node" "3.282.0"
+    "@aws-sdk/util-defaults-mode-node" "3.287.0"
     "@aws-sdk/util-endpoints" "3.272.0"
     "@aws-sdk/util-retry" "3.272.0"
     "@aws-sdk/util-user-agent-browser" "3.282.0"
-    "@aws-sdk/util-user-agent-node" "3.282.0"
+    "@aws-sdk/util-user-agent-node" "3.287.0"
     "@aws-sdk/util-utf8" "3.254.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sso@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.282.0.tgz#9d31cf2eacd6d022213d40ad976ae3a00f99838f"
-  integrity sha512-VzdCCaxlDyU+7wvLDWh+uACQ6RPfaKLQ3yJ2UY0B0SkH4R0E4GLDJ2OJzqS5eyyOsnq1rxfY75S4WYzj8E2cvg==
+"@aws-sdk/client-sso@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.287.0.tgz#b2155bb6832a977d6e02420d5da6ceb6eb41c2dc"
+  integrity sha512-YXD/oP38tsgKYTnft17O6OLTBBdal7CZsRhCJUHUSg3xAV9AiLloMwGrSxcZh4qMhx5bcn9XaVxu8dApsXnJXw==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/config-resolver" "3.282.0"
+    "@aws-sdk/config-resolver" "3.287.0"
     "@aws-sdk/fetch-http-handler" "3.282.0"
     "@aws-sdk/hash-node" "3.272.0"
     "@aws-sdk/invalid-dependency" "3.272.0"
     "@aws-sdk/middleware-content-length" "3.282.0"
     "@aws-sdk/middleware-endpoint" "3.282.0"
     "@aws-sdk/middleware-host-header" "3.282.0"
-    "@aws-sdk/middleware-logger" "3.272.0"
+    "@aws-sdk/middleware-logger" "3.287.0"
     "@aws-sdk/middleware-recursion-detection" "3.282.0"
-    "@aws-sdk/middleware-retry" "3.282.0"
+    "@aws-sdk/middleware-retry" "3.287.0"
     "@aws-sdk/middleware-serde" "3.272.0"
     "@aws-sdk/middleware-stack" "3.272.0"
     "@aws-sdk/middleware-user-agent" "3.282.0"
-    "@aws-sdk/node-config-provider" "3.272.0"
+    "@aws-sdk/node-config-provider" "3.287.0"
     "@aws-sdk/node-http-handler" "3.282.0"
     "@aws-sdk/protocol-http" "3.282.0"
     "@aws-sdk/smithy-client" "3.279.0"
@@ -199,38 +199,38 @@
     "@aws-sdk/util-body-length-browser" "3.188.0"
     "@aws-sdk/util-body-length-node" "3.208.0"
     "@aws-sdk/util-defaults-mode-browser" "3.279.0"
-    "@aws-sdk/util-defaults-mode-node" "3.282.0"
+    "@aws-sdk/util-defaults-mode-node" "3.287.0"
     "@aws-sdk/util-endpoints" "3.272.0"
     "@aws-sdk/util-retry" "3.272.0"
     "@aws-sdk/util-user-agent-browser" "3.282.0"
-    "@aws-sdk/util-user-agent-node" "3.282.0"
+    "@aws-sdk/util-user-agent-node" "3.287.0"
     "@aws-sdk/util-utf8" "3.254.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sts@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.282.0.tgz#1c4355a5d6a8e6af03e752c3273a59c57aaf1715"
-  integrity sha512-JZybEaST0rloS9drlX/0yJAnKHuV7DlS1n1WZxgaM2DY704ydlGiviiPQvC/q/dItsX4017gscC0blGJcUjK1g==
+"@aws-sdk/client-sts@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.287.0.tgz#9de3d0471deabf733c21051f46e42be6c09d06a4"
+  integrity sha512-s6ST78bxSH+nFAFcvSU7bhNAGz/e9Q/77+0Y0JPl/Q2ZWKMfO9AWs/uAieATMBhVuG/8ok4WKrR9YCbMr/ai8A==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/config-resolver" "3.282.0"
-    "@aws-sdk/credential-provider-node" "3.282.0"
+    "@aws-sdk/config-resolver" "3.287.0"
+    "@aws-sdk/credential-provider-node" "3.287.0"
     "@aws-sdk/fetch-http-handler" "3.282.0"
     "@aws-sdk/hash-node" "3.272.0"
     "@aws-sdk/invalid-dependency" "3.272.0"
     "@aws-sdk/middleware-content-length" "3.282.0"
     "@aws-sdk/middleware-endpoint" "3.282.0"
     "@aws-sdk/middleware-host-header" "3.282.0"
-    "@aws-sdk/middleware-logger" "3.272.0"
+    "@aws-sdk/middleware-logger" "3.287.0"
     "@aws-sdk/middleware-recursion-detection" "3.282.0"
-    "@aws-sdk/middleware-retry" "3.282.0"
+    "@aws-sdk/middleware-retry" "3.287.0"
     "@aws-sdk/middleware-sdk-sts" "3.282.0"
     "@aws-sdk/middleware-serde" "3.272.0"
     "@aws-sdk/middleware-signing" "3.282.0"
     "@aws-sdk/middleware-stack" "3.272.0"
     "@aws-sdk/middleware-user-agent" "3.282.0"
-    "@aws-sdk/node-config-provider" "3.272.0"
+    "@aws-sdk/node-config-provider" "3.287.0"
     "@aws-sdk/node-http-handler" "3.282.0"
     "@aws-sdk/protocol-http" "3.282.0"
     "@aws-sdk/smithy-client" "3.279.0"
@@ -240,19 +240,19 @@
     "@aws-sdk/util-body-length-browser" "3.188.0"
     "@aws-sdk/util-body-length-node" "3.208.0"
     "@aws-sdk/util-defaults-mode-browser" "3.279.0"
-    "@aws-sdk/util-defaults-mode-node" "3.282.0"
+    "@aws-sdk/util-defaults-mode-node" "3.287.0"
     "@aws-sdk/util-endpoints" "3.272.0"
     "@aws-sdk/util-retry" "3.272.0"
     "@aws-sdk/util-user-agent-browser" "3.282.0"
-    "@aws-sdk/util-user-agent-node" "3.282.0"
+    "@aws-sdk/util-user-agent-node" "3.287.0"
     "@aws-sdk/util-utf8" "3.254.0"
     fast-xml-parser "4.1.2"
     tslib "^2.3.1"
 
-"@aws-sdk/config-resolver@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.282.0.tgz#b76f3b7daedc2dfca261445f0d222b3d15d693e5"
-  integrity sha512-30qFLh2N4NXQ2EAook7NIFeu1K/nlrRLrdVb2BtGFi/F3cZnz+sy9o0XmL6x+sO9TznWjdNxD1RKQdqoAwGnCQ==
+"@aws-sdk/config-resolver@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.287.0.tgz#1d23e65b338f7877be5f60b172257cb157aba2e0"
+  integrity sha512-YLJ9+ufcrj73DBmqgG50WMAVNHb8PdWL7hkp3gs00VOsXeEMGdQK92fVlx8Him8yPDikvLS2orrEVRcYxj5Uag==
   dependencies:
     "@aws-sdk/signature-v4" "3.282.0"
     "@aws-sdk/types" "3.272.0"
@@ -269,67 +269,67 @@
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-imds@3.272.0":
-  version "3.272.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz#8e740961c2e1f9b93a467e8d5e836e359e18592c"
-  integrity sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==
+"@aws-sdk/credential-provider-imds@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.287.0.tgz#3d4c9efea358a2e02de45599943a7e4ef2398513"
+  integrity sha512-awvsREwUgb9V5pbrP9DyNGh5iXBE8Pbb5EeMw8zJsX+cYuD95N0YncrU/7MAf0+ro851gBqjC3Dty8ujrAhkSg==
   dependencies:
-    "@aws-sdk/node-config-provider" "3.272.0"
+    "@aws-sdk/node-config-provider" "3.287.0"
     "@aws-sdk/property-provider" "3.272.0"
     "@aws-sdk/types" "3.272.0"
     "@aws-sdk/url-parser" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-ini@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.282.0.tgz#60bc1d0fb3cf7053335f42f95f01601f5fdcf4bc"
-  integrity sha512-2GKduXORcUgOigF1jZF7A1Wh4W/aJt3ynh7xb1vfx020nHx6YDljrEGpzgH6pOVzl7ZhgthpojicCuy2UumkMA==
+"@aws-sdk/credential-provider-ini@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.287.0.tgz#04b927297d5c55faa91bd3dccd4f0f1b53a8e6f7"
+  integrity sha512-mDl/twCpXvWUb4A+L3z+v0N4oRF9cnOrkdhW9yP3hBT84RJqCIFHtk966rFiZod8MbhE2LluODtzXVJEIHpmpg==
   dependencies:
     "@aws-sdk/credential-provider-env" "3.272.0"
-    "@aws-sdk/credential-provider-imds" "3.272.0"
-    "@aws-sdk/credential-provider-process" "3.272.0"
-    "@aws-sdk/credential-provider-sso" "3.282.0"
+    "@aws-sdk/credential-provider-imds" "3.287.0"
+    "@aws-sdk/credential-provider-process" "3.287.0"
+    "@aws-sdk/credential-provider-sso" "3.287.0"
     "@aws-sdk/credential-provider-web-identity" "3.272.0"
     "@aws-sdk/property-provider" "3.272.0"
-    "@aws-sdk/shared-ini-file-loader" "3.272.0"
+    "@aws-sdk/shared-ini-file-loader" "3.287.0"
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-node@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.282.0.tgz#90b71f75ae25b8e654b15271b14b0af736a2b2b3"
-  integrity sha512-qyHipZW0ep8STY+SO+Me8ObQ1Ee/aaZTmAK0Os/gB+EsiZhIE+mi6zRcScwdnpgJPLRYMEe4p/Cr6DOrA0G0GQ==
+"@aws-sdk/credential-provider-node@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.287.0.tgz#d15a254ae68b1d47e35085b21956f3d2b99f2807"
+  integrity sha512-7f41hmgwMpMOFgDmpR76xEAXDlG4OHkS1pJU5bt9P4UL2EJWuxvJkdbvI4g9th+lT4cbzWXGFwK+oZ7xBKsVKw==
   dependencies:
     "@aws-sdk/credential-provider-env" "3.272.0"
-    "@aws-sdk/credential-provider-imds" "3.272.0"
-    "@aws-sdk/credential-provider-ini" "3.282.0"
-    "@aws-sdk/credential-provider-process" "3.272.0"
-    "@aws-sdk/credential-provider-sso" "3.282.0"
+    "@aws-sdk/credential-provider-imds" "3.287.0"
+    "@aws-sdk/credential-provider-ini" "3.287.0"
+    "@aws-sdk/credential-provider-process" "3.287.0"
+    "@aws-sdk/credential-provider-sso" "3.287.0"
     "@aws-sdk/credential-provider-web-identity" "3.272.0"
     "@aws-sdk/property-provider" "3.272.0"
-    "@aws-sdk/shared-ini-file-loader" "3.272.0"
+    "@aws-sdk/shared-ini-file-loader" "3.287.0"
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-process@3.272.0":
-  version "3.272.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz#bd0c859554e705c085f0e2ad5dad7e1e43c967ad"
-  integrity sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==
+"@aws-sdk/credential-provider-process@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.287.0.tgz#65579178f17c9384d8467bc9fb393bb5de1c0ede"
+  integrity sha512-3iWtit/4Iyv/JjL2L0cO7v94NvsISTH/ak0CXqAgb2LdCOz0JN3txgg+ciZzdVLUP8M7x/bm4HjMcUVaxS0HZw==
   dependencies:
     "@aws-sdk/property-provider" "3.272.0"
-    "@aws-sdk/shared-ini-file-loader" "3.272.0"
+    "@aws-sdk/shared-ini-file-loader" "3.287.0"
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-sso@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.282.0.tgz#a922821d9e0fa892af131c3774f1ecbd62545cd2"
-  integrity sha512-c4nibry7u0hkYRMi7+cWzdwYXfDDG+j3VYFxk2oOvU1VIJRyE6oeJqVaz3jgYLX9brHyrLJjuFCIJCUV/WXgIA==
+"@aws-sdk/credential-provider-sso@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.287.0.tgz#8cae004ed0e444558461ca8b5d92df5372b47a80"
+  integrity sha512-aJGV4zIFOPWn6PQRjduI3jX+cPCtDtqTNefmsdpw+BIdWFwFINDwoCKfkodnkzxGrB0n35wkGEiddJlwlMwROA==
   dependencies:
-    "@aws-sdk/client-sso" "3.282.0"
+    "@aws-sdk/client-sso" "3.287.0"
     "@aws-sdk/property-provider" "3.272.0"
-    "@aws-sdk/shared-ini-file-loader" "3.272.0"
-    "@aws-sdk/token-providers" "3.282.0"
+    "@aws-sdk/shared-ini-file-loader" "3.287.0"
+    "@aws-sdk/token-providers" "3.287.0"
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
@@ -410,10 +410,10 @@
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-logger@3.272.0":
-  version "3.272.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz#372e2514b17b826a2b40562667e2543125980705"
-  integrity sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==
+"@aws-sdk/middleware-logger@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.287.0.tgz#1750e962c5e616cdb86d8d7b022e4e97f08bf02d"
+  integrity sha512-YZe/3Qs3IelJGK/mUYrCAzTIP1iu6uN4NZCofRP113UXrbipSF+wG2rZWPYyJ/cfAXL1kG4SWtdcKvLiwVEn0g==
   dependencies:
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
@@ -427,10 +427,10 @@
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-retry@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.282.0.tgz#0ddc73f9a41d7990bac2b8221452beb244cf88c5"
-  integrity sha512-3+0M1GP9o480IdqHVZbkhTgge63uKhDFlS6cQznpNGj0eIuQPhXRnlEz2/rma0INUqFm6+7qJ5yzHR4WQbfHpw==
+"@aws-sdk/middleware-retry@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.287.0.tgz#62e2fa750be65a9bc00b544f3bc5564493af194d"
+  integrity sha512-pXIAWuwGpWRWjIIJwbkNQGbhOGoOYVaO5WZZ+65PgKkOVDLeCYU0O26PD5cHw2ksUye8dKGfIXHTbe4CmxDveA==
   dependencies:
     "@aws-sdk/protocol-http" "3.282.0"
     "@aws-sdk/service-error-classification" "3.272.0"
@@ -488,13 +488,13 @@
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/node-config-provider@3.272.0":
-  version "3.272.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz#7797a8f500593b1a7b91fc70bcd7a7245afd9a61"
-  integrity sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==
+"@aws-sdk/node-config-provider@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.287.0.tgz#c706d285afa01f457cd6948e306849d674496fc1"
+  integrity sha512-+AO5dy6JEDvgtH9fcuCNnAQd6ilZjww8d/HNTCb5xOhiW1/pKSNMRhouGfn47uxq61WwDN/qUnv2nlVN83RB6w==
   dependencies:
     "@aws-sdk/property-provider" "3.272.0"
-    "@aws-sdk/shared-ini-file-loader" "3.272.0"
+    "@aws-sdk/shared-ini-file-loader" "3.287.0"
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
@@ -547,10 +547,10 @@
   resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz#cf19b82c2ab1e63bb03793c68e6a2b2e7cbd8382"
   integrity sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==
 
-"@aws-sdk/shared-ini-file-loader@3.272.0":
-  version "3.272.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz#f924ec6e7c183ec749d42e204d8f0d0b7c58fa25"
-  integrity sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==
+"@aws-sdk/shared-ini-file-loader@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.287.0.tgz#9e02200eaf57aaef02d3c304f7818c38e2a21f1f"
+  integrity sha512-CxZp6R11uC12lNg+vKXc8bU7mqIrM43ZY2BbLRZ4tBlc7RLQpcJyccpEwEQAmJq0PA+rDUNod0gYnrM5DOUCLg==
   dependencies:
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
@@ -577,14 +577,14 @@
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
-"@aws-sdk/token-providers@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.282.0.tgz#a3983a121e430f1dce043aeb3251dc6a0887e009"
-  integrity sha512-Qk/D6i+Hpc0fp/2SRHbfJeKPgUIugzsmye3NL0OV1bqd1Y40dW5LT4u67VcZHwqxzYDKe6Eo+7NHJu7qfvwhog==
+"@aws-sdk/token-providers@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.287.0.tgz#0a6336e3a8960e17c5ccbf824e1343ebbbe70512"
+  integrity sha512-RuqgncuQpLD5+W84RbTj/pgJmrjxSPJG0GBAtnISXrc39mGoc0ArOzQUTKIs+cLqDY+WS1/pqXlnQmKvmw3TQw==
   dependencies:
-    "@aws-sdk/client-sso-oidc" "3.282.0"
+    "@aws-sdk/client-sso-oidc" "3.287.0"
     "@aws-sdk/property-provider" "3.272.0"
-    "@aws-sdk/shared-ini-file-loader" "3.272.0"
+    "@aws-sdk/shared-ini-file-loader" "3.287.0"
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
@@ -651,14 +651,14 @@
     bowser "^2.11.0"
     tslib "^2.3.1"
 
-"@aws-sdk/util-defaults-mode-node@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.282.0.tgz#827c6d7c7b6de1493873a789be4d4916ae3163b2"
-  integrity sha512-D1BlFoA7ZMeK2diDUWFx1xBFrSaJuBZMRBuWbnbT9AnRYNCsASZ8DRU1KkZ8LuFQIwmZz94P9q683emYnZBhiw==
+"@aws-sdk/util-defaults-mode-node@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.287.0.tgz#bc03551104f18202862660218780629a0157ed58"
+  integrity sha512-ZGpbPvUA+m+Lf01eTDHkXmulEPT4LphffEt6M9cHPMhwEZfzxhXLyNXyGRunraoBBzB62hKBbFM2atsoHpuIZA==
   dependencies:
-    "@aws-sdk/config-resolver" "3.282.0"
-    "@aws-sdk/credential-provider-imds" "3.272.0"
-    "@aws-sdk/node-config-provider" "3.272.0"
+    "@aws-sdk/config-resolver" "3.287.0"
+    "@aws-sdk/credential-provider-imds" "3.287.0"
+    "@aws-sdk/node-config-provider" "3.287.0"
     "@aws-sdk/property-provider" "3.272.0"
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
@@ -716,12 +716,12 @@
     bowser "^2.11.0"
     tslib "^2.3.1"
 
-"@aws-sdk/util-user-agent-node@3.282.0":
-  version "3.282.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.282.0.tgz#1e8c59b32f7567a07e222ecebb4bcf91398b01f2"
-  integrity sha512-GSOdWNmzEd554wR9HBrgeYptKBOybveVwUkd6ws+YTdCOz4xD5Gga+I5JomKkcMEUVdBrJnYVUtq7ZsJy2f11w==
+"@aws-sdk/util-user-agent-node@3.287.0":
+  version "3.287.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.287.0.tgz#d5ce49b3282142e0bbc700c14350933cf3524d32"
+  integrity sha512-yXg0C3WyxyRkQstR4VCTgnEPQd/ViRz+9rEPkYNIWXPvp1l8hPygk5q9tmSD09Lg8wzm6jR6V0MSyJnbwdzq+g==
   dependencies:
-    "@aws-sdk/node-config-provider" "3.272.0"
+    "@aws-sdk/node-config-provider" "3.287.0"
     "@aws-sdk/types" "3.272.0"
     tslib "^2.3.1"
 
@@ -2287,9 +2287,9 @@ aws-cdk-lib@2.67.0:
     yaml "1.10.2"
 
 aws-cdk@^2:
-  version "2.67.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.67.0.tgz#79c36c0f53cc27ab7375e1c6f541ec839b91adac"
-  integrity sha512-4KvMFEEznqTnpAx7cBrKt/zyJzAGXLcx4h0syd4862qic9CR0/1HzzWgwkOt9eRYKOYT44ElnCtRTIN//FBL6w==
+  version "2.68.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.68.0.tgz#30490bb1ff6b87bebd8a431e6c74336c69964618"
+  integrity sha512-r+C5M4J3C7RLiixhxsO/W9Kpb5iB0mFshyn5PXT1cGPkDbx23bnWLOab03jG7uHWIWI01DCipHQyTaeXXqvT3A==
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -2566,10 +2566,10 @@ case@1.6.3, case@^1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cdk-nag@^2.22.28:
-  version "2.22.28"
-  resolved "https://registry.yarnpkg.com/cdk-nag/-/cdk-nag-2.22.28.tgz#c7a11f18d0230a4ab24224e0dc412adae66a33c1"
-  integrity sha512-0kImhvxYWL8Xrle6in+2ZpAkbNIMT2vHJ0HR3Xtgu0NzTi1Zsb5FAYA3oiLTqg8kUaonrrKycXTR49iYFWPykw==
+cdk-nag@^2.22.29:
+  version "2.22.29"
+  resolved "https://registry.yarnpkg.com/cdk-nag/-/cdk-nag-2.22.29.tgz#e334e5a0eb6f418d736f8b20c6809ea3770a447d"
+  integrity sha512-SgF8h696UZ05FzSHCwq4jQ5oypHr3uO3wiHNmkmtb12mg/3xzGGlzjJf0hR6U/+SwnhEOpSNttRZboNatIDNsA==
 
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
@@ -3229,9 +3229,9 @@ eastasianwidth@^0.2.0:
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 electron-to-chromium@^1.4.284:
-  version "1.4.322"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.322.tgz#e0afa1d115b66c1d47869db40d8f2f3729cecc16"
-  integrity sha512-KovjizNC9XB7dno/2GjxX8VS0SlfPpCjtyoKft+bCO+UfD8bFy16hY4Sh9s0h9BDxbRH2U0zX5VBjpM1LTcNlg==
+  version "1.4.325"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.325.tgz#7b97238a61192d85d055d97f3149832b3617d37b"
+  integrity sha512-K1C03NT4I7BuzsRdCU5RWkgZxtswnKDYM6/eMhkEXqKu4e5T+ck610x3FPzu1y7HVFSiQKZqP16gnJzPpji1TQ==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -5216,10 +5216,10 @@ jsii-diff@^1.77.0:
     log4js "^6.8.0"
     yargs "^16.2.0"
 
-jsii-docgen@^7.1.18:
-  version "7.1.18"
-  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-7.1.18.tgz#a1c6d1feddba0c657c0282b425876544af15db53"
-  integrity sha512-FKpgG+rwXocFOJL6VkWBspReSNZNu/7A1z8IWr1+MtthDuwP9EV/D0e+xUFqzeJojBi1G78BtQvcLeXGnW1FSg==
+jsii-docgen@^7.1.19:
+  version "7.1.19"
+  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-7.1.19.tgz#1c40567d90141253c4d821df803429f21caa39be"
+  integrity sha512-1ZjrVMcMBIlFAAEh7y/jAoYOgwhJlnq3q61Ety/jgsqf3lOhljw8cYMZ6Ap0VE+NZYkD9XD95SOB6YYOpK4PQQ==
   dependencies:
     "@jsii/spec" "^1.77.0"
     case "^1.6.3"
@@ -5543,9 +5543,9 @@ lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log4js@^6.8.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.9.0.tgz#2687c08b330f610054e79c492b35c677c9b183eb"
-  integrity sha512-sAGxJKqxXFlK+05OlMH6SIDAdvgQHj95EfSDOfkHW6BQUlkz+fZw8PWhydfRHq+0UuWYWR55mVnR+KTnWE2JDA==
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.9.1.tgz#aba5a3ff4e7872ae34f8b4c533706753709e38b6"
+  integrity sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==
   dependencies:
     date-format "^4.0.14"
     debug "^4.3.4"
@@ -6431,10 +6431,10 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@0.67.75:
-  version "0.67.75"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.67.75.tgz#64fc75d9e8aaea7ad56424bf78ba0c5d59a8f27e"
-  integrity sha512-cdCRjhyIumTPOlKIaNSl4FtJUV5QC6C11FqbdEXhOBsnLleppo62NoS/renS4IGkruyHyqliX0bXakBCskYiaQ==
+projen@0.67.78:
+  version "0.67.78"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.67.78.tgz#8e3da966cc9a985f691eec532760347ab65179c6"
+  integrity sha512-JgFWbyK26aP4AjG/kS5Ag54+TAzldK7gBZ6UrMFUr4xEvXFmwNBLQYlamb/pmb3XothEKfNN5Qh6WkIqKY9mrg==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,10 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.77.tgz#25ad8e416945c3a51881eedad3ee84516f23ecee"
   integrity sha512-KKrnyIujGN38yOb0MIm0EnB3n7z83NRl9VgKvN0flOyB8C+3Ey+XKxLYfjoXJ/BulB0161eBJXXwGdP8xQrQJw==
 
-"@aws-cdk/aws-synthetics-alpha@2.55.1-alpha.0":
-  version "2.55.1-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-synthetics-alpha/-/aws-synthetics-alpha-2.55.1-alpha.0.tgz#9468361ffbdcf7f4d7aa16c5cdec62e3d7b53811"
-  integrity sha512-GfwQOmeQGQw817teUMr2/m7k8gr4he1oorj5LGBoiZkYbsWBhK1UjNXBa8xYsLdvQM/FUZDClPpz6LBIdtwAFg==
+"@aws-cdk/aws-synthetics-alpha@2.67.0-alpha.0":
+  version "2.67.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-synthetics-alpha/-/aws-synthetics-alpha-2.67.0-alpha.0.tgz#5255cc3868d0a0c8dd8ba105d5a1668e2b837536"
+  integrity sha512-snS5Fl/FSlumSGjSZYvQlXqH2tZjoTozo0iXwiQr1MdG0xLJCoiSqa0vBRhVPP5hsNG6qWQ9LIygi5eFmKG4YQ==
 
 "@aws-cdk/integ-tests-alpha@^2.67.0-alpha.0":
   version "2.67.0-alpha.0"
@@ -3229,9 +3229,9 @@ eastasianwidth@^0.2.0:
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 electron-to-chromium@^1.4.284:
-  version "1.4.323"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.323.tgz#5f91cb03e6b88c0a208ff66c0203a24c6e689506"
-  integrity sha512-+a0hMEQxE8u1F1vOHcE0M18kQ2+4AwOXdRrU4avZ1LeR/sa9WAallYE3uES/PNcEGt/wCFcOgWcArSLx5C+WNQ==
+  version "1.4.322"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.322.tgz#e0afa1d115b66c1d47869db40d8f2f3729cecc16"
+  integrity sha512-KovjizNC9XB7dno/2GjxX8VS0SlfPpCjtyoKft+bCO+UfD8bFy16hY4Sh9s0h9BDxbRH2U0zX5VBjpM1LTcNlg==
 
 emittery@^0.8.1:
   version "0.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,9 +11,9 @@
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@aws-cdk/asset-awscli-v1@^2.2.85":
-  version "2.2.95"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.95.tgz#0bba7976c568c6aefca5032145e0f07f07bcd612"
-  integrity sha512-NehDS2rfGFt9/NCAxX4rIdVb6peFQsME3Ji+i0ENjwiyv52cS2XakW8bJ0IcgNCVQdMm0dnn5r2PQBJ/M62F+Q==
+  version "2.2.97"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.97.tgz#af6fcefe7b9ddecc6656691bd0b4061f5c5eabf2"
+  integrity sha512-bWFkQphw1U7Q8XngShvGy0S1yqDui6q72zjnLciqKQ5ucZq17/TEujLTpSv+v2K5qJU8oa8VaMDiRyYbdPD6MA==
 
 "@aws-cdk/asset-kubectl-v20@^2.1.1":
   version "2.1.1"
@@ -21,9 +21,9 @@
   integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
 
 "@aws-cdk/asset-node-proxy-agent-v5@^2.0.71":
-  version "2.0.76"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.76.tgz#af9b918de5d3932e4f2c3c66b6b222351e08a68a"
-  integrity sha512-TZx7S0k2O1v+sUJowX8C9/2NJptMNtc/D2bFwEZINaMtlF4njq6Ypr6wOaHNw9TvQIJCfqw4/PgKgROGYJL3DA==
+  version "2.0.77"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.77.tgz#25ad8e416945c3a51881eedad3ee84516f23ecee"
+  integrity sha512-KKrnyIujGN38yOb0MIm0EnB3n7z83NRl9VgKvN0flOyB8C+3Ey+XKxLYfjoXJ/BulB0161eBJXXwGdP8xQrQJw==
 
 "@aws-cdk/aws-synthetics-alpha@2.67.0-alpha.0":
   version "2.67.0-alpha.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/asset-awscli-v1@^2.2.85":
+"@aws-cdk/asset-awscli-v1@^2.2.97":
   version "2.2.98"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.98.tgz#74fa0bf8593e9cfbdc68e8eb64977e0adb21cb38"
   integrity sha512-SRJeHb08wW5FVZN7OrbzHzyxW9HuRek2irRCUc+6YBgIRM1JYlyUSd+vcaPThTllNl7rUf4oNvmyK0/3tWLKDg==
@@ -20,7 +20,7 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz#d01c1efb867fb7f2cfd8c8b230b8eae16447e156"
   integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
 
-"@aws-cdk/asset-node-proxy-agent-v5@^2.0.71":
+"@aws-cdk/asset-node-proxy-agent-v5@^2.0.77":
   version "2.0.78"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.78.tgz#dc500bdd5534ca3390d5be7764ca8916c76e6d5d"
   integrity sha512-NMGFaszbLkLQlxIJ0ydyO+P78cgTEUleGt1nn3CSRyuBHoYkHNGAcY2JUxTFhQc3/AZuq1x4w87zqh7eAOTyTw==
@@ -2268,14 +2268,14 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.67.0:
-  version "2.67.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.67.0.tgz#ae9d38bba736e4b92feb740d02d1d25dc80644db"
-  integrity sha512-oVD0cZPKTtkGXvFkYLA+vNiq+QzyuQkOe/rDY/BSxi/cEElbu74StKwCFCFGq8ljTAHQjyYeE5dzlB2q8Wq20w==
+aws-cdk-lib@2.68.0:
+  version "2.68.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.68.0.tgz#5448dfff733a88551e3df61df5c5b646a7b6ee75"
+  integrity sha512-roN3xwzv/GleGG3CaJrf+thdzr9WBzJU4LotumEOs+0cGfeXSta8Pm/cGAeY4kplr5r10QWUovH0fv/bi6Vrbw==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.85"
+    "@aws-cdk/asset-awscli-v1" "^2.2.97"
     "@aws-cdk/asset-kubectl-v20" "^2.1.1"
-    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.71"
+    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.77"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"


### PR DESCRIPTION
Remove pinned version of aws-synthetics-alpha to upgrade to latest.